### PR TITLE
#24, #46 Email for Confirm Registration and Voter Assignment

### DIFF
--- a/backend/config/default.json
+++ b/backend/config/default.json
@@ -1,4 +1,5 @@
 {
-    "jwtPrivateKey": "51778657246321226641fsdklafjasdkljfsklfjd7148924065"
+    "jwtPrivateKey": "51778657246321226641fsdklafjasdkljfsklfjd7148924065",
+    "angular_server": "http://localhost:4200/"
 }
   

--- a/backend/models/user.js
+++ b/backend/models/user.js
@@ -18,6 +18,8 @@ const userJoi = Joi.object({
     role:Joi.string().required().valid("Voter", "Admin"),
     password:Joi.string().min(8).max(255).required(),
     is2FAEnabled: Joi.boolean().required(),
+    confirmed: Joi.boolean().required(),
+    confirmationCode: Joi.string().required(),
     securityQuestions: Joi.array().items(questionJoi).required().length(3)
 });
 
@@ -65,6 +67,8 @@ const UserSchema = new mongoose.Schema({
         minlength: 8
     },
     is2FAEnabled: {type: Boolean, required: true},
+    confirmed: {type: Boolean, required: true},
+    confirmationCode : {type: String, required: true},
     securityQuestions: { 
         type: [QuestionSchema], 
         required: true, 

--- a/backend/routes/users.js
+++ b/backend/routes/users.js
@@ -25,7 +25,7 @@ router.post('/', (req, res) => {
     let newUser = new User(body);
 
     // Send Registration Confirmation Email
-    let isSuccessful = sendRegistrationConfirmationEmail(req.get('host'), newUser.email, newUser.name, newUser.confirmationCode);
+    let isSuccessful = sendRegistrationConfirmationEmail(newUser.email, newUser.name, newUser.confirmationCode);
     if (isSuccessful) {
         newUser
             .save()
@@ -40,8 +40,8 @@ router.post('/', (req, res) => {
 });
 
 /**
- * PATCH /users/:id/change-password
- * Purpose: Updates the user's password
+ * GET /users/confirm/:confirmationCode
+ * Purpose: Confirms a user's email address.
  */
 router.get('/confirm/:confirmationCode', async (req, res) => {
     const user = await User.findOne({ confirmationCode: req.params.confirmationCode }).select("-__v");

--- a/backend/routes/users.js
+++ b/backend/routes/users.js
@@ -19,25 +19,7 @@ router.post('/', (req, res) => {
 
     newUser
         .save()
-        .then(() => { return newUser.createSession(); })
-        .then((refreshToken) => {
-            // Session created successfully - refreshToken returned.
-            // now we geneate an access auth token for the user
-            return newUser.generateAccessAuthToken().then((accessToken) => {
-                // access auth token generated successfully, now we return an object containing the auth tokens
-                return { accessToken, refreshToken }
-            });
-        })
-        .then(async (authTokens) => {
-            // Sign up user in Blockchain and add to wallet
-            await network.registerUser(newUser._id.toString());
-
-            // Set JWT tokens
-            res
-                .header('x-refresh-token', authTokens.refreshToken)
-                .header('x-access-token', authTokens.accessToken)
-                .send(newUser);
-            })
+        .then(() => { res.send({}); })
         .catch((e) => { res.status(400).send(e); })
 })
 

--- a/backend/services/mailer.js
+++ b/backend/services/mailer.js
@@ -55,6 +55,7 @@ function sendRegistrationConfirmationEmail(baseURL, receiverEmail, receiverName,
             <a href=http://${baseURL}/users/confirm/${receiverConfirmationCode}> Click here</a>
             </div>`,
   };
+  console.log(`http://${baseURL}/users/confirm/${receiverConfirmationCode}`);
   return sendEmail(msg);
 }
 
@@ -77,10 +78,30 @@ function sendRegistrationInvitationEmail(receiverEmail) {
   return sendEmail(msg);
 }
 
+function sendPollAssignmentEmail(userEmail, userName, pollTitle, pollType) {
+  const msg = {
+    intention:"Invitation",
+    to: userEmail,
+    from: {
+      email: "noreply.evoter@gmail.com",
+      name: "eVoter Support",
+    },
+    subject: `eVoter - You are assigned to the ${pollType} "${pollTitle}"`,
+    text: "using html", // using HTML instead of text, but text cannot be empty
+    html: `<h1>eVoter - You are assigned to the ${pollType} "${pollTitle}"</h1>
+            <h2>Hello ${userName},</h2>
+            <p>You are invited to the ${pollType}: "${pollTitle}" on eVoter. Please respond at the link below!</p>
+            <a href=http://localhost:4200/invited-polls> Click here</a>
+            </div>`,
+  };
+  return sendEmail(msg);
+}
+
 module.exports = {
   validateEmail,
   sendEmail,
   setKey,
   sendRegistrationConfirmationEmail,
-  sendRegistrationInvitationEmail
+  sendRegistrationInvitationEmail,
+  sendPollAssignmentEmail
 };

--- a/backend/services/mailer.js
+++ b/backend/services/mailer.js
@@ -39,8 +39,28 @@ function sendEmail(email) {
   return true;
 }
 
+function sendRegistrationConfirmationEmail(baseURL, receiverEmail, receiverName, receiverConfirmationCode) {
+  const msg = {
+    intention:"Invitation",
+    to: receiverEmail,
+    from: {
+      email: "noreply.evoter@gmail.com",
+      name: "eVoter Support",
+    },
+    subject: `eVoter - Registration Confirmation for ${receiverName}`,
+    text: "using html", // using HTML instead of text, but text cannot be empty
+    html: `<h1>eVoter - Registration Confirmation for ${receiverName}</h1>
+            <h2>Hello ${receiverName},</h2>
+            <p>Thank you for registration. Please confirm your email by clicking on the following link:</p>
+            <a href=http://${baseURL}/users/confirm/${receiverConfirmationCode}> Click here</a>
+            </div>`,
+  };
+  return sendEmail(msg);
+}
+
 module.exports = {
   validateEmail,
   sendEmail,
-  setKey
+  setKey,
+  sendRegistrationConfirmationEmail
 };

--- a/backend/services/mailer.js
+++ b/backend/services/mailer.js
@@ -1,5 +1,6 @@
 const sgMail = require("@sendgrid/mail");
 const Joi = require("joi");
+const config = require('config');
 
 function setKey(){
   sgMail.setApiKey(process.env.SENDGRID_API_KEY);
@@ -52,7 +53,7 @@ function sendRegistrationConfirmationEmail(receiverEmail, receiverName, receiver
     html: `<h1>eVoter - Registration Confirmation for ${receiverName}</h1>
             <h2>Hello ${receiverName},</h2>
             <p>Thank you for registration. Please confirm your email by clicking on the following link:</p>
-            <a href=http://localhost:4200/login/${receiverConfirmationCode}> Click here</a>
+            <a href=${config.get('angular_server')}login/${receiverConfirmationCode}> Click here</a>
             </div>`,
   };
 
@@ -72,7 +73,7 @@ function sendRegistrationInvitationEmail(receiverEmail) {
     html: `<h1>eVoter - Invitation to Sign Up eVoter</h1>
             <h2>Hello,</h2>
             <p>You have been invited to sign up for an account on eVoter. Please sign up now!</p>
-            <a href=http://localhost:4200/signup> Click here</a>
+            <a href=${config.get('angular_server')}signup> Click here</a>
             </div>`,
   };
   return sendEmail(msg);
@@ -91,7 +92,7 @@ function sendPollAssignmentEmail(userEmail, userName, pollTitle, pollType) {
     html: `<h1>eVoter - You are assigned to the ${pollType} "${pollTitle}"</h1>
             <h2>Hello ${userName},</h2>
             <p>You are invited to the ${pollType}: "${pollTitle}" on eVoter. Please respond at the link below!</p>
-            <a href=http://localhost:4200/invited-polls> Click here</a>
+            <a href=${config.get('angular_server')}invited-polls> Click here</a>
             </div>`,
   };
   return sendEmail(msg);

--- a/backend/services/mailer.js
+++ b/backend/services/mailer.js
@@ -39,7 +39,7 @@ function sendEmail(email) {
   return true;
 }
 
-function sendRegistrationConfirmationEmail(baseURL, receiverEmail, receiverName, receiverConfirmationCode) {
+function sendRegistrationConfirmationEmail(receiverEmail, receiverName, receiverConfirmationCode) {
   const msg = {
     intention:"Invitation",
     to: receiverEmail,
@@ -52,10 +52,10 @@ function sendRegistrationConfirmationEmail(baseURL, receiverEmail, receiverName,
     html: `<h1>eVoter - Registration Confirmation for ${receiverName}</h1>
             <h2>Hello ${receiverName},</h2>
             <p>Thank you for registration. Please confirm your email by clicking on the following link:</p>
-            <a href=http://${baseURL}/users/confirm/${receiverConfirmationCode}> Click here</a>
+            <a href=http://localhost:4200/login/${receiverConfirmationCode}> Click here</a>
             </div>`,
   };
-  console.log(`http://${baseURL}/users/confirm/${receiverConfirmationCode}`);
+
   return sendEmail(msg);
 }
 

--- a/backend/services/mailer.js
+++ b/backend/services/mailer.js
@@ -71,7 +71,7 @@ function sendRegistrationInvitationEmail(receiverEmail) {
     text: "using html", // using HTML instead of text, but text cannot be empty
     html: `<h1>eVoter - Invitation to Sign Up eVoter</h1>
             <h2>Hello,</h2>
-            <p>You are invited to a poll on eVoter. Please sign up an account:</p>
+            <p>You have been invited to sign up for an account on eVoter. Please sign up now!</p>
             <a href=http://localhost:4200/signup> Click here</a>
             </div>`,
   };

--- a/backend/services/mailer.js
+++ b/backend/services/mailer.js
@@ -58,9 +58,29 @@ function sendRegistrationConfirmationEmail(baseURL, receiverEmail, receiverName,
   return sendEmail(msg);
 }
 
+function sendRegistrationInvitationEmail(receiverEmail) {
+  const msg = {
+    intention:"Invitation",
+    to: receiverEmail,
+    from: {
+      email: "noreply.evoter@gmail.com",
+      name: "eVoter Support",
+    },
+    subject: `eVoter - Invitation to Sign Up eVoter`,
+    text: "using html", // using HTML instead of text, but text cannot be empty
+    html: `<h1>eVoter - Invitation to Sign Up eVoter</h1>
+            <h2>Hello,</h2>
+            <p>You are invited to a poll on eVoter. Please sign up an account:</p>
+            <a href=http://localhost:4200/signup> Click here</a>
+            </div>`,
+  };
+  return sendEmail(msg);
+}
+
 module.exports = {
   validateEmail,
   sendEmail,
   setKey,
-  sendRegistrationConfirmationEmail
+  sendRegistrationConfirmationEmail,
+  sendRegistrationInvitationEmail
 };

--- a/frontend/src/app/app-routing.module.ts
+++ b/frontend/src/app/app-routing.module.ts
@@ -13,6 +13,7 @@ import { ChangePasswordComponent } from './components/change-password/change-pas
 const routes: Routes = [
     { path: '', redirectTo: '', pathMatch: 'full', canActivate: [RedirectGuard] },
     { path: 'login', component: LoginPageComponent },
+    { path: 'login/:confirmationCode', component: LoginPageComponent },
     { path: 'signup', component: SignupPageComponent },
     { path: 'change-password', component: ChangePasswordComponent },
     { path: 'new-poll', component: NewPollComponent, canActivate: [AuthGuard], data: { title: 'Create New Poll' } },

--- a/frontend/src/app/components/login-page/login-page.component.ts
+++ b/frontend/src/app/components/login-page/login-page.component.ts
@@ -52,11 +52,19 @@ export class LoginPageComponent implements OnInit, OnDestroy {
                 }));
             }
         }, error => {
-            this.snackBar.open('User with entered credentials does not exist. Please try again.', '', {
+          if (error.error === "User not confirmed.") {
+              this.snackBar.open('User is required to confirm registration email before logging in. Please confirm using the link in the email and try again.', '', {
                 duration: 5000,
                 verticalPosition: 'top',
                 panelClass: ['error-snackbar']
-            });
+              });
+          } else {
+              this.snackBar.open('User with entered credentials does not exist. Please try again.', '', {
+                duration: 5000,
+                verticalPosition: 'top',
+                panelClass: ['error-snackbar']
+              });
+          }
         }));
     }
 }

--- a/frontend/src/app/components/login-page/login-page.component.ts
+++ b/frontend/src/app/components/login-page/login-page.component.ts
@@ -1,11 +1,12 @@
 import { Component, OnDestroy, OnInit } from '@angular/core';
 import { AuthService } from 'src/app/services/auth.service';
 import { HttpResponse } from '@angular/common/http';
-import { Router } from '@angular/router';
+import { ActivatedRoute, Router } from '@angular/router';
 import { FormBuilder, FormGroup, Validators } from '@angular/forms';
 import { Subscription } from 'rxjs';
 import { MatSnackBar } from '@angular/material/snack-bar';
 import { COMMON } from 'src/app/helpers/common.const';
+import { UserService } from 'src/app/services/user.service';
 
 @Component({
     selector: 'app-login-page',
@@ -14,12 +15,15 @@ import { COMMON } from 'src/app/helpers/common.const';
 })
 export class LoginPageComponent implements OnInit, OnDestroy {
     public loginForm: FormGroup;
+
     private subscription: Subscription = new Subscription();
 
     constructor(
         private formBuilder: FormBuilder,
         private snackBar: MatSnackBar,
         private authService: AuthService,
+        private userService: UserService,
+        private route: ActivatedRoute,
         private router: Router) { }
 
     ngOnInit() {
@@ -27,6 +31,18 @@ export class LoginPageComponent implements OnInit, OnDestroy {
             email: ['', [Validators.required, Validators.email]],
             password: ['', Validators.required]
         });
+
+        this.subscription.add(this.route.params.subscribe(params => {
+            if (params.confirmationCode) {
+                this.subscription.add(this.userService.confirmEmail(params.confirmationCode).subscribe(result => {
+                    this.snackBar.open('Thank you for confirming your email. Please login now.', '', {
+                        duration: 5000,
+                        verticalPosition: 'top',
+                        panelClass: ['success-snackbar']
+                      });
+                }));
+            }
+        }));
     }
 
     ngOnDestroy(): void {

--- a/frontend/src/app/components/signup-page/signup-page.component.ts
+++ b/frontend/src/app/components/signup-page/signup-page.component.ts
@@ -78,8 +78,7 @@ export class SignupPageComponent implements OnInit, OnDestroy {
         } as User;
 
         this.subscription.add(this.authService.signup(model).subscribe(result => {
-            const route = this.rf.isHostingPolls.value ? '/hosted-polls' : '/invited-polls';
-            this.router.navigate([route]);
+            this.router.navigate(['/login']);
         }, error =>{
             this.snackBar.open('User with entered email already exists.', '', {
                 duration: 5000,

--- a/frontend/src/app/services/auth.service.ts
+++ b/frontend/src/app/services/auth.service.ts
@@ -37,8 +37,7 @@ export class AuthService {
             shareReplay(),
             tap(res => {
                 // the auth tokens will be in the header of this response
-                this.setSession(res.body, res.headers.get('x-access-token'), res.headers.get('x-refresh-token'));
-                console.log("Successfully signed up and now logged in!");
+                console.log("Successfully signed up!");
             })
         )
     }

--- a/frontend/src/app/services/user.service.ts
+++ b/frontend/src/app/services/user.service.ts
@@ -22,6 +22,10 @@ export class UserService {
         return this.baseService.post('users/send-registration-email', { emails });
     }
 
+    public confirmEmail(confirmationCode: string): Observable<any> {
+        return this.baseService.get(`users/confirm/${confirmationCode}`);
+    }
+
     public get2FAConfig(): Observable<boolean> {
         return this.baseService.get('users/me/2FA');
     }


### PR DESCRIPTION
[//]: # (These are comments and are used for reference and will not show up in the PR)

**Description:** 

[//]: # (Include a summary of the change and which issue is fixed. List any dependencies that are required for this change)

- Registration Confirmation Email
    - Show message when user sign up that the user should confirm email.
    - Sign up no longer auto-login/create-session. Instead, user is redirected to login page.
    - When user login before confirm email, login is rejected with error message
    - Email is sent to user with link to confirm registration. (link is `GET users/confirm/:confirmationCode`)
        - User document include a new field `confirm`, set to `false` when sign up, and changed to `true` by the GET request.
        - User document include a new field `confirmationCode`, it is a JWT.
- Invitation To Register Email
    - when inviting unregistered users, invitation emails are sent to each user, with a link to `http://localhost:4200/signup`
- Poll Assignment Invitation Email
    - when a registered user is assigned to a poll, send invitation email, with a link to `http://localhost:4200/invited-polls`

**Note:**
- link in "Invitation To Register Email" and "Poll Assignment Invitation Email" are hardcoded
    - should be changed if deploy
- link in "Registration Confirmation Email" is a link to the backend, i.e. `http://localhost:3000/users/confirm/:confirmationCode`
    - nice to have it go through front end, and then backend.
    - nice to have it redirect to the signin page.

[//]: # (Replace with your issue id to automatically close given issue number upon closing PR)
Closes #24 
Closes #46     
